### PR TITLE
remove the unused and deprecated `multilingual` field from `book.toml`

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -3,7 +3,6 @@ title = "넷평의 개발 노트"
 description = "study.dev-notes"
 authors = ["netpyoung"]
 language = "ko"
-multilingual = false
 src = "src"
 
 [output.html]


### PR DESCRIPTION
See https://github.com/szabgab/public-mdbooks/issues/10